### PR TITLE
Add open install library instrumentation to mysql

### DIFF
--- a/catalog/mysql/README.md
+++ b/catalog/mysql/README.md
@@ -1,10 +1,10 @@
 # MySQL Demo
-Get your first taste of New Relic infrastructure integrations with MySQL! This demo runs on a single host with a simulator, Node.js application, and a MySQL database.
+Get your first taste of New Relic infrastructure integrations with MySQL and the Open Install Library! This demo runs on a single host with a simulator, Node.js application, and a MySQL database. The Open Install Library is used to automatically instrument the host and MySQL instance with corresponding installation tasks.
 
 ## Prerequisites
-* An environment set up by follow the [Getting Started guide](../../GETTING_STARTED.md)
-* A database password and root password added to the `secrets` of your user configuration file. Like so:
-  ```
+* An environment set up by following the [Getting Started guide](../../GETTING_STARTED.md)
+* A database password and root database password added to the `secrets` of your user configuration file. Like so:
+  ```json
   {
   ...
 
@@ -14,7 +14,7 @@ Get your first taste of New Relic infrastructure integrations with MySQL! This d
     }
   }
   ```
-  Read more about the `secrets` field [here](https://github.com/newrelic/demo-deployer/blob/main/documentation/user_config/secrets.md)
+Read more about the `secrets` field [here](https://github.com/newrelic/demo-deployer/blob/main/documentation/user_config/secrets.md)
 
 ## Guide
 When your environment is ready to go, use one of the commands below to deploy your application.

--- a/catalog/mysql/mysql.aws.json
+++ b/catalog/mysql/mysql.aws.json
@@ -86,32 +86,26 @@
                 "source_repository": "https://github.com/newrelic/demo-newrelic-instrumentation.git",
                 "deploy_script_path": "deploy/node/linux/roles",
                 "version": "6.13.0"
-            },
-            {
-                "id": "nr_mysql_integration",
-                "service_ids": [
-                    "mysql"
-                ],
-                "provider": "newrelic",
-                "source_repository": "https://github.com/newrelic/demo-newrelic-instrumentation.git",
-                "deploy_script_path": "deploy/databases/mysql/linux/roles",
-                "version": "1.4.0",
-                "params": {
-                    "database_root_password": "[credential:secrets:database_root_password]",
-                    "database_port": "[service:mysql:port]"
-                }
             }
         ],
         "resources": [
             {
-                "id": "nr_infra",
-                "resource_ids": [
-                    "host1"
-                ],
+                "id": "nr_open_install_library",
+                "resource_ids": [ "host1" ],
                 "provider": "newrelic",
                 "source_repository": "https://github.com/newrelic/demo-newrelic-instrumentation.git",
-                "deploy_script_path": "deploy/linux/roles",
-                "version": "1.12.4"
+                "deploy_script_path": "deploy/open-install-library/linux/roles",
+                "params": {
+                    "recipe_content_urls": [
+                        "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/amazonlinux2.yml",
+                        "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/logs/logs.yml",
+                        "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml"
+                    ],
+                    "NR_CLI_DB_USERNAME" : "root",
+                    "NR_CLI_DB_PASSWORD" : "[credential:secrets:database_root_password]",
+                    "NR_CLI_DB_PORT" : "[service:mysql:port]",
+                    "NR_CLI_DATABASE" : "[service:node1:id]"
+                }
             }
         ]
     }

--- a/catalog/mysql/mysql.azure.json
+++ b/catalog/mysql/mysql.azure.json
@@ -86,32 +86,26 @@
                 "source_repository": "https://github.com/newrelic/demo-newrelic-instrumentation.git",
                 "deploy_script_path": "deploy/node/linux/roles",
                 "version": "6.13.0"
-            },
-            {
-                "id": "nr_mysql_integration",
-                "service_ids": [
-                    "mysql"
-                ],
-                "provider": "newrelic",
-                "source_repository": "https://github.com/newrelic/demo-newrelic-instrumentation.git",
-                "deploy_script_path": "deploy/databases/mysql/linux/roles",
-                "version": "1.4.0",
-                "params": {
-                    "database_root_password": "[credential:secrets:database_root_password]",
-                    "database_port": "[service:mysql:port]"
-                }
             }
         ],
         "resources": [
             {
-                "id": "nr_infra",
-                "resource_ids": [
-                    "host1"
-                ],
+                "id": "nr_open_install_library",
+                "resource_ids": [ "host1" ],
                 "provider": "newrelic",
                 "source_repository": "https://github.com/newrelic/demo-newrelic-instrumentation.git",
-                "deploy_script_path": "deploy/linux/roles",
-                "version": "1.12.4"
+                "deploy_script_path": "deploy/open-install-library/linux/roles",
+                "params": {
+                    "recipe_content_urls": [
+                        "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/amazonlinux2.yml",
+                        "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/logs/logs.yml",
+                        "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml"
+                    ],
+                    "NR_CLI_DB_USERNAME" : "root",
+                    "NR_CLI_DB_PASSWORD" : "[credential:secrets:database_root_password]",
+                    "NR_CLI_DB_PORT" : "[service:mysql:port]",
+                    "NR_CLI_DATABASE" : "[service:node1:id]"
+                }
             }
         ]
     }

--- a/catalog/mysql/mysql.gcp.json
+++ b/catalog/mysql/mysql.gcp.json
@@ -86,32 +86,26 @@
                 "source_repository": "https://github.com/newrelic/demo-newrelic-instrumentation.git",
                 "deploy_script_path": "deploy/node/linux/roles",
                 "version": "6.13.0"
-            },
-            {
-                "id": "nr_mysql_integration",
-                "service_ids": [
-                    "mysql"
-                ],
-                "provider": "newrelic",
-                "source_repository": "https://github.com/newrelic/demo-newrelic-instrumentation.git",
-                "deploy_script_path": "deploy/databases/mysql/linux/roles",
-                "version": "1.4.0",
-                "params": {
-                    "database_root_password": "[credential:secrets:database_root_password]",
-                    "database_port": "[service:mysql:port]"
-                }
             }
         ],
         "resources": [
             {
-                "id": "nr_infra",
-                "resource_ids": [
-                    "host1"
-                ],
+                "id": "nr_open_install_library",
+                "resource_ids": [ "host1" ],
                 "provider": "newrelic",
                 "source_repository": "https://github.com/newrelic/demo-newrelic-instrumentation.git",
-                "deploy_script_path": "deploy/linux/roles",
-                "version": "1.12.4"
+                "deploy_script_path": "deploy/open-install-library/linux/roles",
+                "params": {
+                    "recipe_content_urls": [
+                        "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/amazonlinux2.yml",
+                        "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/logs/logs.yml",
+                        "https://raw.githubusercontent.com/newrelic/open-install-library/main/recipes/newrelic/infrastructure/ohi/mysql/rhel.yml"
+                    ],
+                    "NR_CLI_DB_USERNAME" : "root",
+                    "NR_CLI_DB_PASSWORD" : "[credential:secrets:database_root_password]",
+                    "NR_CLI_DB_PORT" : "[service:mysql:port]",
+                    "NR_CLI_DATABASE" : "[service:node1:id]"
+                }
             }
         ]
     }


### PR DESCRIPTION
## Summary

[NOTE]: # ( Provide a brief overview of the changes. )
Updates to the MySQL demo to use the Open Install Library to instrument MySQL and the infrastructure.

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [x] Documentation updated
- [x] AWS Deployment configuration updated
- [x] GCP Deployment configuration updated
- [x] Azure Deployment configuration updated

## Reviewers
[NOTE]: # ( Mention reviewers here! )
@gabeobrien @nr-kkenney 