### PR TITLE
Correct database name when deploying mysql demo

### DIFF
--- a/catalog/mysql/mysql.aws.json
+++ b/catalog/mysql/mysql.aws.json
@@ -104,7 +104,7 @@
                     "NR_CLI_DB_USERNAME" : "root",
                     "NR_CLI_DB_PASSWORD" : "[credential:secrets:database_root_password]",
                     "NR_CLI_DB_PORT" : "[service:mysql:port]",
-                    "NR_CLI_DATABASE" : "[service:node1:id]"
+                    "NR_CLI_DATABASE" : "inventory"
                 }
             }
         ]

--- a/catalog/mysql/mysql.azure.json
+++ b/catalog/mysql/mysql.azure.json
@@ -104,7 +104,7 @@
                     "NR_CLI_DB_USERNAME" : "root",
                     "NR_CLI_DB_PASSWORD" : "[credential:secrets:database_root_password]",
                     "NR_CLI_DB_PORT" : "[service:mysql:port]",
-                    "NR_CLI_DATABASE" : "[service:node1:id]"
+                    "NR_CLI_DATABASE" : "inventory"
                 }
             }
         ]

--- a/catalog/mysql/mysql.gcp.json
+++ b/catalog/mysql/mysql.gcp.json
@@ -104,7 +104,7 @@
                     "NR_CLI_DB_USERNAME" : "root",
                     "NR_CLI_DB_PASSWORD" : "[credential:secrets:database_root_password]",
                     "NR_CLI_DB_PORT" : "[service:mysql:port]",
-                    "NR_CLI_DATABASE" : "[service:node1:id]"
+                    "NR_CLI_DATABASE" : "inventory"
                 }
             }
         ]


### PR DESCRIPTION
## Summary

[NOTE]: # ( Provide a brief overview of the changes. )
Fix issue in the MySQL demo where the database name was not getting passed to the MySQL OHI.

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [x] AWS Deployment configuration updated
- [x] GCP Deployment configuration updated
- [x] Azure Deployment configuration updated
